### PR TITLE
✨ Add dialog to edit match entries to snapshot viewer

### DIFF
--- a/src/gui/dialogs/edit_snapshot.py
+++ b/src/gui/dialogs/edit_snapshot.py
@@ -1,0 +1,79 @@
+from PyQt5.QtWidgets import (QDialog, QVBoxLayout, QFormLayout, QLineEdit,
+                           QPushButton, QMessageBox, QComboBox, QHBoxLayout)
+from PyQt5.QtCore import Qt
+
+class EditSnapshotDialog(QDialog):
+    def __init__(self, parent, match_details):
+        super().__init__(parent)
+        self.parent = parent
+        self.match_details = match_details
+        self.setWindowTitle("Edit Match Entry")
+        self.setModal(True)
+        self.init_ui()
+        self.load_data()
+
+    def init_ui(self):
+        layout = QVBoxLayout()
+        form = QFormLayout()
+
+        # Create input fields
+        self.date_input = QLineEdit()
+        self.map_input = QLineEdit()
+        self.outcome_combo = QComboBox()
+        self.outcome_combo.addItems(["VICTORY", "DEFEAT"])
+        self.team_combo = QComboBox()
+        self.team_combo.addItems(["ATTACK", "DEFENSE"])
+
+        # Add fields to form
+        form.addRow("Date:", self.date_input)
+        form.addRow("Map:", self.map_input)
+        form.addRow("Outcome:", self.outcome_combo)
+        form.addRow("Team:", self.team_combo)
+
+        layout.addLayout(form)
+
+        # Buttons
+        button_layout = QHBoxLayout()
+        save_button = QPushButton("Save")
+        save_button.clicked.connect(self.save_changes)
+        cancel_button = QPushButton("Cancel")
+        cancel_button.clicked.connect(self.reject)
+        
+        button_layout.addWidget(save_button)
+        button_layout.addWidget(cancel_button)
+        layout.addLayout(button_layout)
+
+        self.setLayout(layout)
+
+    def load_data(self):
+        try:
+            self.date_input.setText(self.match_details['date'])
+            self.map_input.setText(self.match_details['map'])
+            self.outcome_combo.setCurrentText(self.match_details['outcome'])
+            self.team_combo.setCurrentText(self.match_details['team'])
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to load data: {str(e)}")
+
+    def save_changes(self):
+        try:
+            with self.parent.parent.db.get_connection() as conn:
+                cursor = conn.cursor()
+                cursor.execute("""
+                    UPDATE matches 
+                    SET data = ?, map = ?, outcome = ?, team = ?
+                    WHERE data = ? AND map = ? AND outcome = ? AND team = ?
+                """, (
+                    self.date_input.text(),
+                    self.map_input.text(),
+                    self.outcome_combo.currentText(),
+                    self.team_combo.currentText(),
+                    self.match_details['date'],
+                    self.match_details['map'],
+                    self.match_details['outcome'],
+                    self.match_details['team']
+                ))
+                
+            QMessageBox.information(self, "Success", "Changes saved successfully!")
+            self.accept()
+        except Exception as e:
+            QMessageBox.critical(self, "Error", f"Failed to save changes: {str(e)})")


### PR DESCRIPTION
This pull request introduces a new dialog for editing match entries and adds a context menu to the snapshot viewer. The most important changes include the creation of the `EditSnapshotDialog` class, integration of the new dialog into the snapshot viewer, and the addition of context menu options for viewing, editing, and deleting entries.

### New dialog for editing match entries:
* [`src/gui/dialogs/edit_snapshot.py`](diffhunk://#diff-c1c0e0c9ecf0917d359958fd51154b26025e65803c3b5005b69c2df854ffb017R1-R79): Created a new `EditSnapshotDialog` class that allows users to edit match entries with fields for date, map, outcome, and team, and save changes to the database.

### Integration into snapshot viewer:
* [`src/gui/dialogs/snapshot_viewer.py`](diffhunk://#diff-60233beb72cb96cc3c094c8588002038026c48b87ff2022ddb5f1d49ea1a3732L4-R8): Imported the `EditSnapshotDialog` class to integrate it into the snapshot viewer.

### Context menu additions:
* [`src/gui/dialogs/snapshot_viewer.py`](diffhunk://#diff-60233beb72cb96cc3c094c8588002038026c48b87ff2022ddb5f1d49ea1a3732R56-R59): Added a context menu to the snapshot viewer table with options to view details, edit entries, and delete entries. [[1]](diffhunk://#diff-60233beb72cb96cc3c094c8588002038026c48b87ff2022ddb5f1d49ea1a3732R56-R59) [[2]](diffhunk://#diff-60233beb72cb96cc3c094c8588002038026c48b87ff2022ddb5f1d49ea1a3732R325-R363)

## Summary by Sourcery

Adds the ability to edit snapshot entries via a new dialog and context menu in the snapshot viewer. This allows users to modify match details such as date, map, outcome, and team.

New Features:
- Introduces a dialog for editing match entries.
- Adds a context menu to the snapshot viewer with options to view details, edit entries, and delete entries.