### PR TITLE
✏️ Standardize the Naming of Stat Groups

### DIFF
--- a/src/gui/tabs/attacker_tab.py
+++ b/src/gui/tabs/attacker_tab.py
@@ -98,18 +98,18 @@ class AttackerTab(QWidget):
                 ("Total Vehicle Damage", "vehicle_damage_total"),    # Added
                 ("Average Vehicle Damage", "vehicle_damage_avg"),    # Added
             ],
-            "Match Stats": [
+            "Match Performance": [
                 ("Total Games", "games_total"),
                 ("Victories", "victories"),
                 ("Win Rate", "win_rate", "%"),
                 ("Average Rank", "avg_rank"),
             ],
-            "Score Analysis": [
+            "Score Performance": [
                 ("Total Score", "score_total"),
                 ("Average Score", "score_avg"),
                 ("Best Score", "score_best"),
             ],
-            "Support Activities": [
+            "Support Performance": [
                 ("Total Assists", "assists_total"),
                 ("Average Assists", "assists_avg"),
                 ("Total Revives", "revives_total"),
@@ -122,7 +122,7 @@ class AttackerTab(QWidget):
                 ("Average Captures", "captures_avg"),
                 ("Best Captures", "captures_best"),
             ],
-            "Ticket Management": [                    # Moved to last position
+            "Ticket Performance": [                    # Moved to last position
                 ("Tickets Lost", "tickets_lost"),     
                 ("Tickets Saved", "tickets_saved"),   
                 ("Net Ticket Impact", "tickets_net"), 

--- a/src/gui/tabs/class_tab.py
+++ b/src/gui/tabs/class_tab.py
@@ -78,14 +78,14 @@ class ClassTab(QWidget):
                 
                 # Reorganized stat groups to match overall tab
                 stat_groups = {
-                    "Performance Summary": [
+                    "Match Performance": [
                         ("Games Played:", class_data[1]),
                         ("Victories:", class_data[16]),
                         ("Defeats:", class_data[17]),
                         ("Win Rate:", f"{class_data[18]:.1f}%"),
                         ("Average Rank:", int(class_data[15]))
                     ],
-                    "Combat Stats": [
+                    "Combat Performance": [
                         ("Total Score:", class_data[2]),  # This is now total_score
                         ("Average Score:", int(class_data[2] / class_data[1]) if class_data[1] > 0 else 0),  # Calculate average from total
                         ("Best Score:", class_data[3])  # This is now best_score
@@ -99,7 +99,7 @@ class ClassTab(QWidget):
                         ("Total Vehicle Damage:", class_data[19]),
                         ("Average Vehicle Damage:", int(class_data[20]))
                     ],
-                    "Support Stats": [
+                    "Support Performance": [
                         ("Total Assists:", class_data[9]),
                         ("Average Assists:", int(class_data[10])),
                         ("Total Revives:", class_data[11]),
@@ -107,7 +107,7 @@ class ClassTab(QWidget):
                         ("Total Tactical Respawns:", class_data[21]),
                         ("Average Tactical Respawns:", int(class_data[22]))
                     ],
-                    "Objective Stats": [
+                    "Objective Performance": [
                         ("Total Captures:", class_data[13]),
                         ("Average Captures:", int(class_data[14]))
                     ]

--- a/src/gui/tabs/defender_tab.py
+++ b/src/gui/tabs/defender_tab.py
@@ -98,18 +98,18 @@ class DefenderTab(QWidget):
                 ("Total Vehicle Damage", "vehicle_damage_total"),    # Added
                 ("Average Vehicle Damage", "vehicle_damage_avg"),    # Added
             ],
-            "Match Stats": [
+            "Match Performance": [
                 ("Total Games", "games_total"),
                 ("Victories", "victories"),
                 ("Win Rate", "win_rate", "%"),
                 ("Average Rank", "avg_rank"),
             ],
-            "Score Analysis": [
+            "Score Performance": [
                 ("Total Score", "score_total"),
                 ("Average Score", "score_avg"),
                 ("Best Score", "score_best"),
             ],
-            "Support Activities": [
+            "Support Performance": [
                 ("Total Assists", "assists_total"),
                 ("Average Assists", "assists_avg"),
                 ("Total Revives", "revives_total"),

--- a/src/gui/tabs/map_tab.py
+++ b/src/gui/tabs/map_tab.py
@@ -43,12 +43,12 @@ class MapTab(QWidget):
         
         # Define stat groups
         groups = {
-            "General": [
+            "Match Performance": [
                 ("Total Games", "games_played"),
                 ("Win Rate", "win_rate", "%"),
                 ("Average Rank", "avg_rank"),
             ],
-            "Combat": [
+            "Combat Performance ": [
                 ("Average Score", "avg_score"),
                 ("Best Score", "best_score"),
                 ("Average Kills", "avg_kills"),
@@ -58,7 +58,7 @@ class MapTab(QWidget):
                 ("Total Vehicle Damage", "total_vehicle_damage"),
                 ("Average Vehicle Damage", "avg_vehicle_damage"),
             ],
-            "Support": [
+            "Support Performance": [
                 ("Average Assists", "avg_assists"),
                 ("Best Assists", "best_assists"),
                 ("Average Revives", "avg_revives"),
@@ -66,7 +66,7 @@ class MapTab(QWidget):
                 ("Total Tactical Respawns", "total_tactical_respawn"),
                 ("Average Tactical Respawns", "avg_tactical_respawn"),
             ],
-            "Objective": [
+            "Objective Performance": [
                 ("Average Captures", "avg_captures"),
                 ("Best Captures", "best_captures")
             ]

--- a/src/gui/tabs/overall_tab.py
+++ b/src/gui/tabs/overall_tab.py
@@ -394,13 +394,13 @@ def setup_overall_tab(dialog):
                 *[(f"{class_name} Games:", f"{count} ({pct}%)")
                   for class_name, count, pct in class_stats],
             ],
-            "Match Results": [
+            "Match Performance": [
                 ("Victories:", victories),
                 ("Defeats:", defeats),
                 ("Win Rate:", win_rate),
                 ("Average Rank:", stats[19] if stats else 0),
             ],
-            "Combat Stats": [
+            "Combat Performance": [
                 ("Total Score:", stats[1] if stats else 0),
                 ("Average Score:", stats[2] if stats else 0),
                 ("Best Score:", stats[3] if stats else 0),
@@ -414,7 +414,7 @@ def setup_overall_tab(dialog):
                 ("Total Vehicle Damage:", stats[15] if stats else 0),
                 ("Average Vehicle Damage:", stats[16] if stats else 0),
             ],
-            "Support Stats": [
+            "Support Performance": [
                 ("Total Assists:", stats[9] if stats else 0),
                 ("Average Assists:", stats[10] if stats else 0),
                 ("Total Revives:", stats[11] if stats else 0),
@@ -422,7 +422,7 @@ def setup_overall_tab(dialog):
                 ("Total Tactical Respawns:", stats[17] if stats else 0),
                 ("Average Tactical Respawns:", stats[18] if stats else 0),
             ],
-            "Objective Stats": [
+            "Objective Performance": [
                 ("Total Captures:", stats[13] if stats else 0),
                 ("Average Captures:", stats[14] if stats else 0),
             ]


### PR DESCRIPTION
This pull request includes changes to standardize the naming of stat groups across multiple files in the `src/gui/tabs` directory. The changes primarily involve renaming existing stat groups to ensure a consistent naming convention is used throughout the application.

Renaming stat groups for consistency:

* [`src/gui/tabs/attacker_tab.py`](diffhunk://#diff-4f186482dd4c958198976deed97a36e1f3478ca0bad95882b82a749d5af3652bL101-R112): Renamed stat groups such as "Match Stats" to "Match Performance", "Score Analysis" to "Score Performance", and "Support Activities" to "Support Performance". Additionally, moved "Ticket Management" to the last position and renamed it to "Ticket Performance". [[1]](diffhunk://#diff-4f186482dd4c958198976deed97a36e1f3478ca0bad95882b82a749d5af3652bL101-R112) [[2]](diffhunk://#diff-4f186482dd4c958198976deed97a36e1f3478ca0bad95882b82a749d5af3652bL125-R125)
* [`src/gui/tabs/class_tab.py`](diffhunk://#diff-a41f06521023b9a7534591e9ab14dc11d4594bf2772279ae3cb33224895743f5L81-R88): Renamed stat groups such as "Performance Summary" to "Match Performance", "Combat Stats" to "Combat Performance", and "Support Stats" to "Support Performance". [[1]](diffhunk://#diff-a41f06521023b9a7534591e9ab14dc11d4594bf2772279ae3cb33224895743f5L81-R88) [[2]](diffhunk://#diff-a41f06521023b9a7534591e9ab14dc11d4594bf2772279ae3cb33224895743f5L102-R110)
* [`src/gui/tabs/defender_tab.py`](diffhunk://#diff-2b05e74057ac62a1a016277ad31757fd7c3e101d464f893ff031007a5769367eL101-R112): Renamed stat groups such as "Match Stats" to "Match Performance", "Score Analysis" to "Score Performance", and "Support Activities" to "Support Performance".
* [`src/gui/tabs/map_tab.py`](diffhunk://#diff-11dcf81c2cb703f4a8e5ef43a035108c4c97975ebf665fb7e1261380ad905c8aL46-R51): Renamed stat groups such as "General" to "Match Performance", "Combat" to "Combat Performance", and "Support" to "Support Performance". [[1]](diffhunk://#diff-11dcf81c2cb703f4a8e5ef43a035108c4c97975ebf665fb7e1261380ad905c8aL46-R51) [[2]](diffhunk://#diff-11dcf81c2cb703f4a8e5ef43a035108c4c97975ebf665fb7e1261380ad905c8aL61-R69)
* [`src/gui/tabs/overall_tab.py`](diffhunk://#diff-121073f404576381498868e51b49f45b55b17a97a232034347d6bcfc350e7fdaL397-R403): Renamed stat groups such as "Match Results" to "Match Performance", "Combat Stats" to "Combat Performance", and "Support Stats" to "Support Performance". [[1]](diffhunk://#diff-121073f404576381498868e51b49f45b55b17a97a232034347d6bcfc350e7fdaL397-R403) [[2]](diffhunk://#diff-121073f404576381498868e51b49f45b55b17a97a232034347d6bcfc350e7fdaL417-R425)

Closes #16

## Summary by Sourcery

Standardize the naming of stat groups across multiple files in the `src/gui/tabs` directory to ensure a consistent naming convention is used throughout the application.

Enhancements:
- Rename stat groups to `Match Performance`, `Combat Performance`, `Support Performance`, and `Objective Performance`.
- Move `Ticket Management` to the last position and rename it to `Ticket Performance` in the attacker tab.